### PR TITLE
feat: TouchCountTracker

### DIFF
--- a/src/component/TouchDataAccordion.vue
+++ b/src/component/TouchDataAccordion.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="touch-data-container">
+    <div v-for="(value, key) in displayData" :key="key" class="data-item">
+      <div class="data-label">{{ formatLabel(key) }}:</div>
+      <div class="data-value">{{ value }}</div>
+    </div>
+
+    <div class="accordion">
+      <div class="accordion-header" @click="toggleCoordinates">
+        <div class="flex items-center justify-between w-full">
+          <span>touchCoordinates(터치 좌표 데이터) ({{ touchData.touchCoordinates.length }}개)</span>
+          <span class="toggle-icon">{{ isOpen ? '▲' : '▼' }}</span>
+        </div>
+      </div>
+      <div v-if="isOpen" class="accordion-content">
+        <div v-for="(coord, index) in touchData.touchCoordinates" :key="index" class="coordinate-item">
+          <div class="coordinate-header">좌표 #{{ index + 1 }}</div>
+          <div class="coordinate-details">
+            <div>X: {{ coord.x }}</div>
+            <div>Y: {{ coord.y }}</div>
+            <div>시간: {{ new Date(coord.time_millis).toLocaleString() }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import type { TouchEventData } from '@/module/touchCountTracker'
+
+const props = defineProps<{
+  touchData: TouchEventData
+}>()
+
+const isOpen = ref(false)
+
+type DisplayDataKeys = Exclude<keyof TouchEventData, 'touchCoordinates'>
+
+const displayData = computed(() => {
+  const result: Partial<TouchEventData> = {}
+  const keysToShow: DisplayDataKeys[] = ['touchStartCount', 'touchEndCount', 'touchCancelCount', 'totalTouches', 'activeTouches']
+
+  keysToShow.forEach(key => {
+    result[key] = props.touchData[key]
+  })
+
+  return result
+})
+
+const toggleCoordinates = () => {
+  isOpen.value = !isOpen.value
+}
+
+const formatLabel = (key: string) => {
+  const labels: Record<string, string> = {
+    touchStartCount: 'touchStartCount(터치 시작 횟수)',
+    touchEndCount: 'touchEndCount(터치 종료 횟수)',
+    touchCancelCount: 'touchCancelCount(터치 취소 횟수)',
+    totalTouches: 'totalTouches(전체 터치 횟수)',
+    activeTouches: 'activeTouches(현재 활성 터치)'
+  }
+  return labels[key] || key
+}
+</script>
+
+<style scoped>
+.touch-data-container {
+  font-family: monospace;
+  background-color: #f8f9fa;
+  padding: 1rem;
+  border-radius: 5px;
+  border: 1px solid #ddd;
+}
+
+.data-item {
+  display: flex;
+  margin-bottom: 0.5rem;
+}
+
+.data-label {
+  font-weight: bold;
+  margin-right: 1rem;
+  min-width: 150px;
+}
+
+.accordion {
+  margin-top: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.accordion-header {
+  padding: 0.75rem;
+  background-color: #f1f1f1;
+  cursor: pointer;
+  user-select: none;
+}
+
+.accordion-header:hover {
+  background-color: #e9e9e9;
+}
+
+.toggle-icon {
+  font-size: 0.8rem;
+}
+
+.accordion-content {
+  padding: 1rem;
+  background-color: white;
+}
+
+.coordinate-item {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  border: 1px solid #eee;
+  border-radius: 4px;
+}
+
+.coordinate-header {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+  color: #666;
+}
+
+.coordinate-details {
+  padding-left: 1rem;
+}
+
+.coordinate-details>div {
+  margin-bottom: 0.25rem;
+}
+</style>

--- a/src/component/TouchPage.vue
+++ b/src/component/TouchPage.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="title-container">
+    <h2>{{ pageTitle }}</h2>
+    <div class="button-wrapper">
+      <button :disabled="isFirstPage" @click="goToPreviousPage">
+        이전 페이지
+      </button>
+      <button :disabled="isLastPage" @click="goToNextPage">다음 페이지</button>
+    </div>
+  </div>
+  <TouchDataAccordion :touchData="touchData" />
+
+</template>
+
+<script setup lang="ts">
+import { type PropType } from 'vue'
+import type { TouchEventData } from '@/module/touchCountTracker'
+import TouchDataAccordion from './TouchDataAccordion.vue'
+
+defineProps({
+  pageTitle: {
+    type: String,
+    required: true,
+  },
+  isFirstPage: {
+    type: Boolean,
+    required: false,
+  },
+  isLastPage: {
+    type: Boolean,
+    required: false,
+  },
+  goToPreviousPage: {
+    type: Function as PropType<() => void>,
+  },
+  goToNextPage: {
+    type: Function as PropType<() => void>,
+  },
+  touchData: {
+    type: Object as PropType<TouchEventData>,
+    required: true,
+  },
+})
+</script>
+
+<style scoped>
+.title-container {
+  padding: 24px;
+
+  h2 {
+    width: 100%;
+    text-align: center;
+    font-size: 1.25rem;
+    margin-bottom: 1rem;
+    font-weight: 600;
+  }
+
+  .button-wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    gap: 8px;
+
+    button {
+      padding: 0.5rem 1rem;
+      background-color: #007bff;
+      color: white;
+      border: none;
+      border-radius: 5px;
+      cursor: pointer;
+
+      &:hover {
+        background-color: #0056b3;
+      }
+
+      &:disabled {
+        background-color: #aaa;
+        cursor: not-allowed;
+      }
+
+    }
+  }
+
+}
+</style>

--- a/src/module/touchCountTracker.ts
+++ b/src/module/touchCountTracker.ts
@@ -1,0 +1,196 @@
+/**
+ * Interface for storing individual touch event details
+ */
+interface TouchCoordinate {
+  x: number
+  y: number
+  time_millis: number
+}
+
+/**
+ * Interface for storing touch event data
+ * @interface TouchEventData
+ */
+export interface TouchEventData {
+  /** Number of touch start events occurred */
+  touchStartCount: number
+  /** Number of touch end events occurred */
+  touchEndCount: number
+  /** Number of touch cancel events occurred */
+  touchCancelCount: number
+  /** Total number of touch gestures */
+  totalTouches: number
+  /** Current number of active touch points */
+  activeTouches: number
+  /** List of touch coordinates */
+  touchCoordinates: TouchCoordinate[]
+}
+
+/**
+ * Interface for TouchCountTracker configuration
+ * @interface TouchCountTrackerConfig
+ */
+export interface TouchCountTrackerConfig {
+  /** Callback function to be called on touch end */
+  onTouchEnd?: (data: TouchEventData) => void
+  /** Callback function to be called on touch cancel */
+  onTouchCancel?: (data: TouchEventData) => void
+}
+
+/**
+ * Class for tracking and managing user touch events
+ * Handles multi-touch gestures (e.g., pinch zoom) as a single touch event
+ */
+export default class TouchCountTracker {
+  private touchData: TouchEventData
+  private config: TouchCountTrackerConfig
+  private isTracking: boolean
+  private isMultiTouchActive: boolean
+  private currentTouchIdentifiers: Set<number>
+  private readonly storageKey = 'touchData'
+
+  /**
+   * Creates a TouchCountTracker instance
+   * @param config - Touch event callback configuration
+   */
+  constructor(config: TouchCountTrackerConfig) {
+    this.touchData = {
+      touchStartCount: 0,
+      touchEndCount: 0,
+      touchCancelCount: 0,
+      totalTouches: 0,
+      activeTouches: 0,
+      touchCoordinates: [],
+    }
+    this.config = config
+    this.isTracking = false
+    this.isMultiTouchActive = false
+    this.currentTouchIdentifiers = new Set()
+    this.loadFromStorage()
+  }
+
+  /**
+   * Load saved touch data from localStorage
+   * @private
+   */
+  private loadFromStorage(): void {
+    const savedData = localStorage.getItem(this.storageKey)
+    if (savedData) {
+      try {
+        const parsedData = JSON.parse(savedData)
+        this.touchData = parsedData
+      } catch (error) {
+        console.error('Failed to parse saved touch data:', error)
+      }
+    }
+  }
+
+  /**
+   * Save current touch data to localStorage
+   * @private
+   */
+  private saveToStorage(): void {
+    try {
+      localStorage.setItem(this.storageKey, JSON.stringify(this.touchData))
+    } catch (error) {
+      console.error('Failed to save touch data:', error)
+    }
+  }
+
+  private handleTouchStart = (event: TouchEvent): void => {
+    Array.from(event.changedTouches).forEach((touch) => {
+      this.currentTouchIdentifiers.add(touch.identifier)
+      this.touchData.touchCoordinates.push({
+        x: touch.clientX,
+        y: touch.clientY,
+        time_millis: Date.now(),
+      })
+    })
+
+    if (this.currentTouchIdentifiers.size === 1) {
+      this.touchData.touchStartCount++
+    }
+
+    this.touchData.activeTouches = event.touches.length
+
+    if (event.touches.length > 1) {
+      this.isMultiTouchActive = true
+    }
+
+    this.saveToStorage()
+  }
+
+  private handleTouchEnd = (event: TouchEvent): void => {
+    Array.from(event.changedTouches).forEach((touch) => {
+      this.currentTouchIdentifiers.delete(touch.identifier)
+    })
+
+    this.touchData.activeTouches = event.touches.length
+
+    if (this.currentTouchIdentifiers.size === 0) {
+      this.touchData.touchEndCount++
+      this.touchData.totalTouches++
+      this.isMultiTouchActive = false
+    }
+
+    if (this.config.onTouchEnd) {
+      this.config.onTouchEnd(this.touchData)
+    }
+
+    this.saveToStorage()
+  }
+
+  private handleTouchCancel = (event: TouchEvent): void => {
+    Array.from(event.changedTouches).forEach((touch) => {
+      this.currentTouchIdentifiers.delete(touch.identifier)
+    })
+
+    this.touchData.touchCancelCount++
+
+    if (this.currentTouchIdentifiers.size === 0) {
+      this.isMultiTouchActive = false
+    }
+
+    if (this.config.onTouchCancel) {
+      this.config.onTouchCancel(this.touchData)
+    }
+
+    this.saveToStorage()
+  }
+
+  public startTracking(): void {
+    if (this.isTracking) return
+
+    this.isTracking = true
+    document.addEventListener('touchstart', this.handleTouchStart)
+    document.addEventListener('touchend', this.handleTouchEnd)
+    document.addEventListener('touchcancel', this.handleTouchCancel)
+  }
+
+  public stopTracking(): void {
+    if (!this.isTracking) return
+
+    this.isTracking = false
+    document.removeEventListener('touchstart', this.handleTouchStart)
+    document.removeEventListener('touchend', this.handleTouchEnd)
+    document.removeEventListener('touchcancel', this.handleTouchCancel)
+  }
+
+  public getData(): TouchEventData {
+    return { ...this.touchData }
+  }
+
+  resetData(): void {
+    this.touchData = {
+      touchStartCount: 0,
+      touchEndCount: 0,
+      touchCancelCount: 0,
+      totalTouches: 0,
+      activeTouches: 0,
+      touchCoordinates: [],
+    }
+    this.isMultiTouchActive = false
+    this.currentTouchIdentifiers.clear()
+    this.saveToStorage()
+  }
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,6 +9,11 @@ const router = createRouter({
       name: 'home',
       component: HomeView,
     },
+    {
+      path: '/touch-count',
+      name: 'touch-count',
+      component: () => import('@/view/TouchCountView.vue'),
+    },
   ],
 })
 

--- a/src/view/TouchCountView.vue
+++ b/src/view/TouchCountView.vue
@@ -1,0 +1,71 @@
+<template>
+  <div>
+    <div ref="pageRef">
+      <TouchPage v-if="currentPage === 1" :pageTitle="'Task Page 1'" :isFirstPage="true" :goToNextPage="goToNextPage"
+        :touchData="touchData" />
+      <TouchPage v-if="currentPage === 2" :pageTitle="'Task Page 2'" :goToNextPage="goToNextPage"
+        :goToPreviousPage="goToPreviousPage" :touchData="touchData" />
+      <TouchPage v-if="currentPage === 3" :pageTitle="'Task Page 3'" :isLastPage="true"
+        :goToPreviousPage="goToPreviousPage" :touchData="touchData" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+
+import TouchCountTracker from '@/module/touchCountTracker'
+import type { TouchEventData } from '@/module/touchCountTracker'
+
+import TouchPage from '@/component/TouchPage.vue'
+
+const currentPage = ref(1)
+const pageRef = ref<HTMLElement | null>(null)
+const touchData = ref<TouchEventData>({
+  touchStartCount: 0,
+  touchEndCount: 0,
+  touchCancelCount: 0,
+  totalTouches: 0,
+  activeTouches: 0,
+  touchCoordinates: [
+    {
+      x: 0,
+      y: 0,
+      time_millis: 0,
+    }
+  ]
+})
+
+const tracker = new TouchCountTracker({
+  onTouchEnd: (data) => {
+    touchData.value = { ...data }
+  },
+})
+
+onMounted(() => {
+  tracker.startTracking()
+})
+
+onUnmounted(() => {
+  tracker.stopTracking()
+})
+
+const goToNextPage = () => {
+  if (currentPage.value < 3) {
+    currentPage.value++
+  }
+}
+
+const goToPreviousPage = () => {
+  if (currentPage.value > 1) {
+    currentPage.value--
+  }
+}
+</script>
+
+<style scoped>
+.page-container {
+  min-height: 100vh;
+  padding: 1rem;
+}
+</style>


### PR DESCRIPTION
# 터치 횟수(N회) 수집 모듈

<img width="1904" alt="TouchCountTracker" src="https://github.com/user-attachments/assets/a0574bba-5858-4576-89f9-248242acf6d9" />


## 요구사항
시작 화면에서 테마 선택 이후 데이터 시각화 화면 표출까지 사용자가 터치한 횟수 측정 
_(완료 전 이탈하는 경우는 전체 데이터에 포함하지 않음)_

> - `touch start` ~ `touch end` 완료한 터치의 횟수
> - 터치 시작하였으나 도중에 취소한 `touch cancel` 횟수는 수집하지 않음 
> - 2개 이상의 손가락으로 조작해야 하는 경우 `1회`로 측정 
> - 슬라이드 하는 경우 (`touch start` 지점과 `touch end` 완료 지점이 다른 경우) `1회`로 측정


<br>

## 참고 사항

1. `/touch-count`에서 테스트할 수 있습니다.
2. `touch event`를 수집하기 때문에, PC의 경우 개발자 도구에서 `모바일 해상도`로 테스트해야 **터치 횟수를 인식합니다**
3. 3개의 페이지를 컴포넌트로 나타내어, `TouchCountTracker`를 시나리오에 맞춰 사용할 화면에만 적용시킬 수 있는 예제를 구성했습니다.
    ```mermaid
    graph TD
      A[TouchCountView.vue] --> B[TouchPage.vue]
      A --> C[TouchPage.vue]
      A --> D[TouchPage.vue]
    
    ```


4. 예상되는 데이터 수집 양상
    - row 데이터: 
         ```json
        {
          "touchStartCount": 0,  
          "touchEndCount": 0,
          "touchCancelCount": 0,
          "totalTouches": 0,
           "touchCoordinates": [
              {
                "x": 0,
                "y": 0,
                "time_millis": 0,
              }
           ]
        }
        ```
    
    - 기획 최종 요구 데이터: 
         ```json
        {
          "totalTouches": 0,
        }
         ```


       
      필드 이름 | 설명
      -- | --
      touchStartCount | 사용자가 화면을 터치하기 시작한 횟수
      touchEndCount | 사용자가 화면에서 손을 뗀 횟수 (터치 종료)
      touchCancelCount | 터치가 취소된 횟수 (예: 터치가 중단되거나 잘못된 터치 처리)
      totalTouches | 화면에 대한 총 터치 횟수 (터치 시작과 종료를 모두 포함)
      totalCoordinates | 모든 터치 이벤트 좌표(x, y)와 타임스탬프(timestamp)의 배열




