### PR TITLE
feat: useSwipeUpGesture

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router'
-import GNB from './component/GNB.vue'
-import VideoModal from './component/VideoModal.vue'
-import CommonModal from './component/CommonModal.vue'
+import GNB from '@/component/GNB.vue'
+import VideoModal from '@/component/VideoModal.vue'
+import CommonModal from '@/component/CommonModal.vue'
+import AirConditioningPanel from '@/component/AirConditioningPanel.vue'
+
 </script>
 
 <template>
   <RouterView />
   <GNB />
+  <AirConditioningPanel :is-dismissible="true" />
   <VideoModal />
   <CommonModal />
 </template>

--- a/src/component/AirConditioningPanel.vue
+++ b/src/component/AirConditioningPanel.vue
@@ -1,0 +1,88 @@
+<template>
+  <div class="drag-area" @touchstart="handleTouchStart" @touchmove="handleTouchMove" @touchend="handleTouchEnd">
+    <div class="dim" v-if="modalVisible" @touchstart="handleDimTouch">
+    </div>
+
+    <div class="air-conditioning-panel" :style="{ transform: `translateY(${translateY}px)` }">
+      <div class="drag-handle"></div>
+      <div class="content">Air Conditioning Panel</div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useSwipeUpGesture } from '@/composable/useSwipeUpGesture'
+
+
+const props = defineProps({
+  isDismissible: {
+    type: Boolean,
+    default: false,
+  }
+})
+
+const { translateY, modalVisible, handleTouchStart, handleTouchMove, handleTouchEnd } = useSwipeUpGesture()
+
+const handleDimTouch = (): void => {
+
+  if (props.isDismissible) {
+    translateY.value = 300
+    modalVisible.value = false
+  }
+}
+</script>
+
+<style>
+.drag-area {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  height: 40px;
+  z-index: 20;
+
+  .dim {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.2);
+    z-index: 1;
+  }
+
+  .air-conditioning-panel {
+    position: fixed;
+    z-index: 20;
+    bottom: 0;
+    width: 100%;
+    height: 300px;
+    background-color: white;
+    box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.2);
+    border-top-left-radius: 20px;
+    border-top-right-radius: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transition: transform 0.2s ease-out;
+
+    .content {
+      width: 100%;
+      height: 100%;
+      font-size: 16px;
+      font-weight: 600;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+    }
+
+    .drag-handle {
+      width: 40px;
+      height: 4px;
+      background-color: gray;
+      border-radius: 2px;
+      margin: 10px 0;
+    }
+  }
+}
+</style>

--- a/src/composable/useSwipeUpGesture.ts
+++ b/src/composable/useSwipeUpGesture.ts
@@ -1,0 +1,87 @@
+import { ref } from 'vue'
+
+export const useSwipeUpGesture = () => {
+  const modalVisible = ref<boolean>(false)
+  const startY = ref<number>(0)
+  const currentY = ref<number>(0)
+  const isDragging = ref<boolean>(false)
+  const translateY = ref<number>(300)
+  const upwardThreshold = ref<number>(100)
+  const downwardThreshold = ref<number>(10)
+  const minDragDistance = ref<number>(20)
+
+  const handleTouchStart = (event: TouchEvent): void => {
+    const clientY: number = event.touches[0].clientY
+    startY.value = clientY
+    currentY.value = clientY
+
+    if (modalVisible.value || clientY > window.innerHeight * 0.8) {
+      isDragging.value = true
+    } else {
+      isDragging.value = false
+    }
+  }
+
+  const handleTouchMove = (event: TouchEvent): void => {
+    if (!isDragging.value) return
+
+    const clientY: number = event.touches[0].clientY
+    currentY.value = clientY
+    const deltaY: number = startY.value - currentY.value
+
+    if (Math.abs(deltaY) > minDragDistance.value) {
+      if (modalVisible.value) {
+        translateY.value = Math.max(0, Math.min(300, -deltaY))
+      } else {
+        translateY.value = Math.max(0, Math.min(300, 300 - deltaY))
+      }
+    }
+  }
+
+  const handleTouchEnd = (): void => {
+    if (!isDragging.value) {
+      resetDragState()
+      return
+    }
+
+    const deltaY: number = startY.value - currentY.value
+
+    if (Math.abs(deltaY) <= minDragDistance.value) {
+      translateY.value = modalVisible.value ? 0 : 300
+      resetDragState()
+      return
+    }
+
+    if (modalVisible.value) {
+      if (-deltaY > downwardThreshold.value) {
+        translateY.value = 300
+        modalVisible.value = false
+      } else {
+        translateY.value = 0
+      }
+    } else {
+      if (deltaY > upwardThreshold.value) {
+        translateY.value = 0
+        modalVisible.value = true
+      } else {
+        translateY.value = 300
+      }
+    }
+
+    resetDragState()
+  }
+
+  const resetDragState = (): void => {
+    startY.value = 0
+    currentY.value = 0
+    isDragging.value = false
+  }
+
+  return {
+    modalVisible,
+    translateY,
+    handleTouchStart,
+    handleTouchMove,
+    handleTouchEnd,
+  }
+}


### PR DESCRIPTION
# useSwipeUpGesture 컴포저블


  <img src="https://github.com/user-attachments/assets/5adce401-6f8a-42f1-9c59-bf6e6b00f96e" alt="useSwipeUpGesture gif" width="240" />

## 1. 개요
1. `TouchEvent`를 사용하고 vue의 상태관리, `ref를` 활용하여 `바텀 스와이프 업 제스처`를 최대한 모바일 네이티브처럼 사용할 수 있는  `useSwipeUpGesture` 이름의  `컴포저블`을 만들었습니다.
    (기존 PointerEvents에서는 제스처가 섬세하게 동작하지 않았었는데, TouchEvent로 해결. [👇🏻 하단 부록 참고](#appendix) )
3. 또한 이 `컴포저블`을 사용하여 `AirConditioningPanel.vue`(공조패널 예제)를 만들어 적용하였고, `App.vue`에서 테스트할 수 있도록 사용 예제를 설정해두었습니다.

4. 파일 구조
    ```
    src/
    │
    ├── composable/
    │   └── useSwipeUpGesture.ts       # useSwipeUpGesture 컴포저블
    │
    ├── component/
    │   └── AirConditioningPanel.vue   # AirConditioningPanel 컴포넌트
    │
    └── App.vue                        # 앱의 루트 컴포넌트
    
    ```
   ``` mermaid
   graph TB
    A[App.vue] -->|use| B[AirConditioningPanel.vue]
    B -->|use| C[useSwipeUpGesture.ts]
   ```


<br>


## 2. useSwipeUpGesture 정리

### 2.1. 상태 관리

```tsx
const modalVisible = ref<boolean>(false)   // 패널의 표시 여부
const startY = ref<number>(0)              // 터치 시작 지점의 Y 좌표
const currentY = ref<number>(0)            // 현재 터치 지점의 Y 좌표
const isDragging = ref<boolean>(false)     // 드래그 동작 여부
const translateY = ref<number>(300)        // 패널의 Y축 위치 (0: 완전히 열림, 300: 완전히 닫힘)
const upwardThreshold = ref<number>(100)   // 위로 스와이프 시 패널을 열기 위한 임계값
const downwardThreshold = ref<number>(10)  // 아래로 스와이프 시 패널을 닫기 위한 임계값
const minDragDistance = ref<number>(20)    // 최소 드래그 거리 임계값
```

<br>

### 2.2. 터치 이벤트 핸들러

#### 2.2.1. handleTouchStart

터치가 시작될 때 호출되는 `핸들러`입니다.

```tsx
const handleTouchStart = (event: TouchEvent): void => {
  const clientY: number = event.touches[0].clientY
  startY.value = clientY
  currentY.value = clientY

  if (modalVisible.value || clientY > window.innerHeight * 0.8) {
    isDragging.value = true
  } else {
    isDragging.value = false
  }
}
```

- 패널이 열려있거나(`modalVisible`이 true) 화면 하단 20% 영역을 터치한 경우에만 드래그를 활성화
- 터치 시작 좌표를 `startY`와 `currentY`에 저장

<br>

#### 2.2.2. handleTouchMove

터치 이동 시 호출되는 `핸들러`입니다.

```tsx
const handleTouchMove = (event: TouchEvent): void => {
  if (!isDragging.value) return

  const clientY: number = event.touches[0].clientY
  currentY.value = clientY
  const deltaY: number = startY.value - currentY.value // 이동 거리 계산

  if (Math.abs(deltaY) > minDragDistance.value) {
    if (modalVisible.value) {
      translateY.value = Math.max(0, Math.min(300, -deltaY))
    } else {
      translateY.value = Math.max(0, Math.min(300, 300 - deltaY))
    }
  }
}
```

- `deltaY`: 터치 시작점과 현재 위치의 차이값
- 최소 드래그 거리(`minDragDistance`) 이상 이동했을 때만 패널 위치 업데이트
- 패널 상태에 따라 다른 계산식 적용:
    - 열린 상태: 0에서 시작하여 아래로 드래그
    - 닫힌 상태: 300에서 시작하여 위로 드래그
- `Math.max`와 `Math.min`으로 패널이 0~300 범위를 벗어나지 않도록 제한

<br>


#### 2.2.3. handleTouchEnd

터치가 종료될 때 호출되는 핸들러입니다.

```tsx
const handleTouchEnd = (): void => {
  if (!isDragging.value) {
    resetDragState()
    return
  }

  const deltaY: number = startY.value - currentY.value

  if (Math.abs(deltaY) <= minDragDistance.value) {
    translateY.value = modalVisible.value ? 0 : 300
    resetDragState()
    return
  }

  if (modalVisible.value) {
    if (-deltaY > downwardThreshold.value) {
      translateY.value = 300
      modalVisible.value = false
    } else {
      translateY.value = 0
    }
  } else {
    if (deltaY > upwardThreshold.value) {
      translateY.value = 0
      modalVisible.value = true
    } else {
      translateY.value = 300
    }
  }

  resetDragState()
}
```

- 최소 드래그 거리보다 작게 이동한 경우 현재 상태 유지
- 패널 상태에 따라 다른 로직 적용:
    - 열린 상태에서:
        - 아래로 충분히 드래그(`downwardThreshold` 초과)하면 패널 닫기
        - 그렇지 않으면 다시 열린 상태로 복귀
    - 닫힌 상태에서:
        - 위로 충분히 드래그(`upwardThreshold` 초과)하면 패널 열기
        - 그렇지 않으면 다시 닫힌 상태로 복귀

<br>

### 2.3. 보조 함수

#### 2.3.1. resetDragState

`드래그 상태`를 초기화하는 함수입니다.

```tsx
const resetDragState = (): void => {
  startY.value = 0
  currentY.value = 0
  isDragging.value = false
}
```

- 터치 종료 시 모든 드래그 관련 상태를 초기화
- 다음 터치 동작을 위한 준비

<br>

### 2.4. 반환값

```tsx
return {
  modalVisible,     // 패널 표시 상태
  translateY,       // 패널의 현재 Y축 위치
  handleTouchStart, // 터치 시작 핸들러
  handleTouchMove,  // 터치 이동 핸들러
  handleTouchEnd    // 터치 종료 핸들러
}
```

- 컴포넌트에서 필요한 상태값과 이벤트 핸들러들을 반환
- 이 값들을 이용해 실제 UI 컴포넌트에서 스와이프 동작 구현


<br>


## 3. 부록: `PointerEvents` vs `TouchEvents` {#appendix}

### 3.1. 공통점:

- 둘 다 `사용자 입력 이벤트`로, **UI 요소와의 상호작용**을 처리하는 데 사용됩니다.
- 둘 모두 **DOM 이벤트 시스템**의 일부로, 이벤트 리스너를 통해 처리됩니다.
- 두 이벤트 모두 사용자가 **화면을 터치하거나 포인터 장치를 사용**할 때 발생합니다.

<br>

### 3.2. **`PointerEvent`**:

- **더 일반적인 이벤트 시스템**: `PointerEvent`는 마우스, 터치, 스타일러스 등 다양한 입력 장치를 모두 다룰 수 있습니다.
    - 즉, 하나의 이벤트 시스템으로 여러 입력 장치를 처리할 수 있게 합니다.
- `PointerEvent`**는** `MouseEvent`**, `T**ouchEvent`**, `P**enEvent` **등을 통합한 상위 이벤트**로, 웹 애플리케이션에서 다양한 포인터 입력을 처리할 때 유용하게 사용할 수 있습니다.
- **속성**:
    - `pointerId`: 이벤트를 발생시킨 포인터의 고유 ID.
    - `pointerType`: 포인터의 종류(예: 'mouse', 'touch', 'pen').
    - `pressure`: 펜 또는 스타일러스와 같은 장치에서 압력 정도를 나타낼 수 있어.
    - `width`/`height`: 포인터의 크기 (주로 터치나 스타일러스에서 사용).


<br>

### 3.2. **`TouchEvent`**:

- **주로 터치스크린 장치에서 사용**:
    - `TouchEvent`는 주로 모바일 기기나 터치스크린이 있는 디바이스에서 발생하는 이벤트를 처리할 때 사용됩니다.
- **기본적으로 멀티터치 지원**: 한 번에 여러 손가락을 인식할 수 있습니다.
    - `TouchEvent`는 사용자가 화면을 터치할 때마다 발생하며, 여러 손가락이 동시에 화면을 터치하는 경우 각각의 터치에 대해 정보를 제공할 수 있습니다.
- **속성**:
    - `touches`: 현재 화면에서 활성화된 모든 터치의 리스트.
    - `targetTouches`: 이벤트가 발생한 요소에 현재 활성화된 터치의 리스트.
    - `changedTouches`: 이 이벤트로 인해 영향을 받은 터치들만 포함된 리스트.


<br>

### 3.3. 차이점:

- **사용 범위**: `TouchEvent`는 오직 터치 장치에서만 발생하는 반면, `PointerEvent`는 터치뿐만 아니라 마우스, 펜, 스타일러스 등 다양한 입력 장치에서 발생할 수 있습니다.
- **멀티터치**: `TouchEvent`는 여러 터치 포인트를 다룰 수 있지만, `PointerEvent`는 하나의 포인터에 대한 정보만 제공하고, 멀티터치를 처리하려면 여러 `PointerEvent`를 다뤄야 합니다.
- **유연성**: `PointerEvent`는 여러 입력 장치를 다룰 수 있어서, 마우스나 터치뿐만 아니라, 다른 포인터 장치도 한 번에 처리할 수 있어 더 유연하게 사용할 수 있습니다.

<br>

특징 | PointerEvent | TouchEvent
-- | -- | --
지원하는 장치 | 마우스, 터치, 스타일러스, 펜 등 다양한 입력 장치 | 주로 터치스크린 장치(모바일, 태블릿)에서 사용
멀티터치 지원 | 멀티터치를 처리하려면 여러 이벤트를 처리해야 함 | 멀티터치 자체를 기본으로 지원 (여러 손가락 인식)
주요 속성 | - pointerId (고유 ID) | - touches, targetTouches, changedTouches
  | - pointerType (입력 장치 종류: 'mouse', 'touch', 'pen') | - 각 터치에 대한 정보 제공
다룰 수 있는 포인터 | 마우스, 터치, 스타일러스, 펜 등 다양한 포인터 장치 | 터치에 대해서만 처리
이벤트 종류 | pointerdown, pointermove, pointerup 등 | touchstart, touchmove, touchend 등
압력 감지 | pressure (스타일러스나 펜의 압력 감지 가능) | 없음
크기 정보 | width, height (스타일러스, 터치의 크기 정보 제공) | 없음



<br>

### 3.4. 결론:

- `PointerEvent`는 **마우스, 터치, 스타일러스** 등을 모두 포괄하는 이벤트 시스템으로, 다양한 입력 장치에서의 동작을 한 번에 처리할 수 있습니다.
- `TouchEvent`는 주로 **모바일** 장치나 **터치 스크린**에서 사용되며 멀티터치를 다룰 수 있습니다.

<br>

> _참고:_
> - [Pointer events | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events)
> - [Touch events | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events)